### PR TITLE
HOTFIX: UTF-8 handling in decoding of included message in Bounce request

### DIFF
--- a/lib/DaxMailer/Web/Service/Bounce.pm
+++ b/lib/DaxMailer/Web/Service/Bounce.pm
@@ -6,6 +6,9 @@ use HTTP::Tiny;
 use Try::Tiny;
 use AWS::SNS::Verify;
 use DaxMailer::Base::Web::Service;
+use JSON::MaybeXS 'JSON';
+
+my $j = JSON::MaybeXS->new(utf8 => 0);
 
 sub verify_subscription {
     my $ok = 1;
@@ -40,7 +43,7 @@ post '/handler' => sub {
     if ( $packet->{Type} eq 'SubscriptionConfirmation' ) {
         return verify_subscription( $packet );
     }
-    my $message = decode_json( $packet->{Message} );
+    my $message = $j->decode( $packet->{Message} );
     return rset('Subscriber::Bounce')->handle_bounces( $message );
 };
 

--- a/t/bounces.t
+++ b/t/bounces.t
@@ -9,6 +9,10 @@ BEGIN {
     $ENV{DAXMAILER_MAIL_TEST} = 1;
 }
 
+use Encode;
+use charnames ':full';
+use open ':std', ':encoding(UTF-8)';
+
 use Plack::Test;
 use Plack::Builder;
 use HTTP::Request::Common;
@@ -59,6 +63,11 @@ test_psgi $app => sub {
 
     is( rset('Subscriber')->unbounced->count, 2,
         'Transient bounce received - 2 subscribers remain' );
+
+    ok( $cb->( POST '/bounce/handler',
+            'Content-Type' => 'application/json',
+            Content => sns->sns_permanent_bounce( encode( 'UTF-8', "test\N{OHM SIGN}\@duckduckgo.com" ) )
+        )->is_success, "Permanent bounce message about test\N{OHM SIGN}\@duckduckgo.com" );
 
     ok( $cb->( POST '/bounce/handler',
             'Content-Type' => 'application/json',


### PR DESCRIPTION
Dancer2's `json_decode` simple builtin does not give control over character encoding.

Since the deserialized POST body is already character decoded as well, we are not sending UTF-8 bytes to the `decode_json` call for the nested message blob.