### PR TITLE
Redirect after POST

### DIFF
--- a/lib/DaxMailer/Web/App/Subscriber.pm
+++ b/lib/DaxMailer/Web/App/Subscriber.pm
@@ -135,6 +135,12 @@ post '/friends' => sub {
     forward '/friends', {}, { method => 'GET' };
 };
 
+get '/a' => sub {
+    template 'email/message',
+        { title => 'Thank you!', message => 'Thank you!' },
+        { layout => 'mail' };
+};
+
 post '/a' => sub {
     my $params = params('body');
     if ( !$subscriber->add( $params ) ) {
@@ -142,9 +148,7 @@ post '/a' => sub {
         return "NOT OK" unless $params->{page};
     }
     return "OK" unless $params->{page};
-    return template 'email/message',
-        { title => 'Thank you!', message => 'Thank you!' },
-        { layout => 'mail' };
+    redirect '/a';
 };
 
 get '/add/:email' => sub {

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+BEGIN {
+    use File::Spec::Functions;
+    $ENV{DAXMAILER_DB_DSN} = 'dbi:SQLite:dbname=:memory:';
+    $ENV{DAXMAILER_MAIL_TEST} = 1;
+}
+
+use lib 't/lib';
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+use Test::More;
+use DaxMailer::Base::Web::Common;
+use DaxMailer::TestUtils;
+use DaxMailer::Web::App::Subscriber;
+
+DaxMailer::TestUtils::deploy( { drop => 1 }, schema );
+
+my $app = builder {
+    mount '/s' => DaxMailer::Web::App::Subscriber->to_app;
+};
+
+
+test_psgi $app => sub {
+    my ( $cb ) = @_;
+
+    my $res = $cb->(
+        POST '/s/a',
+        [ email => 'test@ddg.gg', campaign => 'a', flow => 'foo', page => 1 ]
+    );
+    is( $res->code, 302, 'Redirect after POST' );
+    like( $res->header( 'Location' ), qr{/s/a$}, 'Redirect location' );
+
+    $res = $cb->( GET '/s/a' );
+    is( $res->code, 200, 'GET add endpoint' );
+    like( $res->decoded_content, qr{thank\ you}i, 'GET add endpoint' );
+};
+
+done_testing;

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -35,7 +35,7 @@ test_psgi $app => sub {
 
     $res = $cb->( GET '/s/a' );
     is( $res->code, 200, 'GET add endpoint' );
-    like( $res->decoded_content, qr{thank\ you}i, 'GET add endpoint' );
+    like( $res->decoded_content, qr{thank\ you}i, 'Landing page content' );
 };
 
 done_testing;


### PR DESCRIPTION
After submitting your address, it seems all-too easy to issue a new request, whether through refresh or other means. If this second request is a GET, you'll get a 404 message. If it's a POST, you'll likely get caught up in the rate-limiting code.

This change redirects after POST so refreshing or reloading has neither of these ill effects.