### PR TITLE
Delete unsubscribed users

### DIFF
--- a/bin/delete_unsubbed.pl
+++ b/bin/delete_unsubbed.pl
@@ -6,4 +6,4 @@ use DaxMailer::Script::DeleteUnsubbed;
 use DaxMailer::Script::DeleteMailtrainUnsubbed;
 
 DaxMailer::Script::DeleteUnsubbed->new->go;
-#DaxMailer::Script::DeleteMailtrainUnsubbed->new->go;
+DaxMailer::Script::DeleteMailtrainUnsubbed->new->go;

--- a/bin/delete_unsubbed.pl
+++ b/bin/delete_unsubbed.pl
@@ -3,5 +3,7 @@
 use FindBin;
 use lib $FindBin::Dir . "/../lib";
 use DaxMailer::Script::DeleteUnsubbed;
+use DaxMailer::Script::DeleteMailtrainUnsubbed;
 
-use DaxMailer::Script::DeleteUnsubbed->new->go;
+DaxMailer::Script::DeleteUnsubbed->new->go;
+DaxMailer::Script::DeleteMailtrainUnsubbed->new->go;

--- a/bin/delete_unsubbed.pl
+++ b/bin/delete_unsubbed.pl
@@ -6,4 +6,4 @@ use DaxMailer::Script::DeleteUnsubbed;
 use DaxMailer::Script::DeleteMailtrainUnsubbed;
 
 DaxMailer::Script::DeleteUnsubbed->new->go;
-DaxMailer::Script::DeleteMailtrainUnsubbed->new->go;
+#DaxMailer::Script::DeleteMailtrainUnsubbed->new->go;

--- a/bin/delete_unsubbed.pl
+++ b/bin/delete_unsubbed.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+use DaxMailer::Script::DeleteUnsubbed;
+
+use DaxMailer::Script::DeleteUnsubbed->new->go;

--- a/lib/DaxMailer/Schema/Result/Subscriber.pm
+++ b/lib/DaxMailer/Schema/Result/Subscriber.pm
@@ -84,7 +84,7 @@ sub verify {
 
 sub unsubscribe {
     my ( $self, $key ) = @_;
-    $self->update({ unsubscribed => 1 })
+    $self->delete()
         if ( $key eq $self->u_key );
 }
 

--- a/lib/DaxMailer/Schema/ResultSet/Subscriber/Bounce.pm
+++ b/lib/DaxMailer/Schema/ResultSet/Subscriber/Bounce.pm
@@ -37,8 +37,7 @@ sub legacy_unsub {
     return unless $self->legacy_dbh;
 
     $self->legacy_dbh->do(
-       "UPDATE subscriber
-        SET    unsubscribed = 1
+       "DELETE FROM subscriber
         WHERE  email_address = ?",
         undef, ( $email )
     );

--- a/lib/DaxMailer/Schema/ResultSet/Subscriber/Mailtrain.pm
+++ b/lib/DaxMailer/Schema/ResultSet/Subscriber/Mailtrain.pm
@@ -48,7 +48,7 @@ sub process {
         processed => 0, operation => $_,
         created => { '>' => $dt },
     })->process_subscription( $_ )
-        for ( qw/ subscribe unsubscribe delete / );
+        for ( qw/ subscribe unsubscribe / );
 }
 
 sub manage_subscription {

--- a/lib/DaxMailer/Schema/ResultSet/Subscriber/Mailtrain.pm
+++ b/lib/DaxMailer/Schema/ResultSet/Subscriber/Mailtrain.pm
@@ -48,7 +48,7 @@ sub process {
         processed => 0, operation => $_,
         created => { '>' => $dt },
     })->process_subscription( $_ )
-        for ( qw/ subscribe unsubscribe / );
+        for ( qw/ subscribe unsubscribe delete / );
 }
 
 sub manage_subscription {

--- a/lib/DaxMailer/Schema/ResultSet/Subscriber/Mailtrain.pm
+++ b/lib/DaxMailer/Schema/ResultSet/Subscriber/Mailtrain.pm
@@ -59,8 +59,12 @@ sub manage_subscription {
             email_address => $email,
             operation => $operation,
         } );
-        $subscriber->processed( 0 );
-        $subscriber->update;
+        if ( $operation eq 'unsubscribe' ) {
+            $subscriber->delete() if ( $operation eq 'unsubscribe' );
+        } else {
+            $subscriber->processed( 0 );
+            $subscriber->update;
+        }
     } catch {
         warn sprintf( "Unable to %s %s", $operation, $email );
         return 0;
@@ -69,7 +73,16 @@ sub manage_subscription {
 
 sub unsubscribe {
     my ( $self, $email ) = @_;
+    $self->delete_from_mailtrain($email);
     $self->manage_subscription( unsubscribe => $email );
+}
+
+sub delete_from_mailtrain {
+    my ( $self, $email ) = @_;
+    $self->search({
+      email_address => $email,
+      operation => 'unsubscribe',
+    } )->process_subscription( qw/ unsubscribe / );
 }
 
 sub subscribe {

--- a/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
+++ b/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
@@ -11,7 +11,7 @@ sub go {
 
     rset('Subscriber::Mailtrain')->search(
         { 'unsubscribed' => 1 }
-    )->process_subscription('delete');
+    )->process_subscription('unsubscribe'); # This will now delete the user too
 }
 
 1;

--- a/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
+++ b/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+package DaxMailer::Script::DeleteMailtrainUnsubbed;
+
+use Moo;
+
+with 'DaxMailer::Base::Script::Service';
+
+sub go {
+    my ( $self ) = @_;
+
+    rset('Subscriber::Mailtrain')->search(
+        { 'unsubscribed' => 1 }
+    )->process_subscription('delete');
+}
+
+1;

--- a/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
+++ b/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
@@ -11,7 +11,11 @@ sub go {
 
     my @unsubbed_users = rset('Subscriber::Mailtrain')->search(
         { operation => 'unsubscribe' }
-    )->process_subscription( qw/ unsubscribe / ); # This will now delete the user too
+    );
+
+    for my $unsubbed ( @unsubbed_users ) {
+        rset('Subscriber::Mailtrain')->unsubscribe( $unsubbed->email_address );
+    }
 }
 
 1;

--- a/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
+++ b/lib/DaxMailer/Script/DeleteMailtrainUnsubbed.pm
@@ -9,9 +9,9 @@ with 'DaxMailer::Base::Script::Service';
 sub go {
     my ( $self ) = @_;
 
-    rset('Subscriber::Mailtrain')->search(
-        { 'unsubscribed' => 1 }
-    )->process_subscription('unsubscribe'); # This will now delete the user too
+    my @unsubbed_users = rset('Subscriber::Mailtrain')->search(
+        { operation => 'unsubscribe' }
+    )->process_subscription( qw/ unsubscribe / ); # This will now delete the user too
 }
 
 1;

--- a/lib/DaxMailer/Script/DeleteUnsubbed.pm
+++ b/lib/DaxMailer/Script/DeleteUnsubbed.pm
@@ -12,6 +12,8 @@ sub go {
     my $unsubbed = rset('Subscriber::Bounce')->search(
         { 'unsubscribed' => 1 }
     );
+
+    $unsubbed->delete();
 }
 
 1;

--- a/lib/DaxMailer/Script/DeleteUnsubbed.pm
+++ b/lib/DaxMailer/Script/DeleteUnsubbed.pm
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+package DaxMailer::Script::DeleteUnsubbed;
+
+use Moo;
+
+with 'DaxMailer::Base::Script::Service';
+
+sub go {
+    my ( $self ) = @_;
+
+    my $unsubbed = rset('Subscriber::Bounce')->search(
+        { 'unsubscribed' => 1 }
+    );
+}
+
+1;

--- a/lib/DaxMailer/Script/DeleteUnsubbed.pm
+++ b/lib/DaxMailer/Script/DeleteUnsubbed.pm
@@ -9,11 +9,7 @@ with 'DaxMailer::Base::Script::Service';
 sub go {
     my ( $self ) = @_;
 
-    my $unsubbed = rset('Subscriber::Bounce')->search(
-        { 'unsubscribed' => 1 }
-    );
-
-    $unsubbed->delete();
+    rset('Subscriber')->unsubscribed->delete();
 }
 
 1;

--- a/lib/Mailtrain/API.pm
+++ b/lib/Mailtrain/API.pm
@@ -65,6 +65,7 @@ sub subscription {
 sub unsubscribe {
     my ( $self, @emails ) = @_;
     $self->subscription( 'unsubscribe', @emails );
+    $self->subscription( 'delete', @emails );
 }
 
 sub subscribe {


### PR DESCRIPTION
In this PR:
- Delete DaxMailer and Mailtrain users when they unsubscribe
- Scripts to retroactively delete all previously unsubscribed users

In addition to manual testing, make sure to run `perl -Ilib t/*` to verify all automated tests pass.
Manual testing steps are in the task.