### PR TITLE
Remove Privacy Crash Course graduates

### DIFF
--- a/bin/delete_graduated.pl
+++ b/bin/delete_graduated.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+use DaxMailer::Script::DeletePCCGraduated;
+
+DaxMailer::Script::DeletePCCGraduated->new->go;

--- a/lib/DaxMailer/Schema/ResultSet/Subscriber.pm
+++ b/lib/DaxMailer/Schema/ResultSet/Subscriber.pm
@@ -95,6 +95,21 @@ sub mail_sent_days_ago {
     } );
 }
 
+sub mail_sent {
+    my ( $self, $campaign, $email ) = @_;
+    $self->search_rs( {
+        'me.email_address' => { -in => \[
+                'SELECT email_address
+                 FROM subscriber_maillog
+                 WHERE campaign = ?
+                 AND email_address = me.email_address
+                 AND email_id = ?',
+                ( $campaign, $email )
+            ],
+        }
+    } );
+}
+
 sub verification_mail_unsent_for {
     my ( $self, $campaign ) = @_;
     $self->search_rs( {

--- a/lib/DaxMailer/Script/DeletePCCGraduated.pm
+++ b/lib/DaxMailer/Script/DeletePCCGraduated.pm
@@ -11,7 +11,6 @@ sub go {
 
     my $campaigns = config()->{campaigns};
     for my $campaign ( sort keys %{ $campaigns } ) {
-        next if !$campaigns->{ $campaign }->{live};
         my @mail_map = (
             'v',
             sort { $a <=> $b }

--- a/lib/DaxMailer/Script/DeletePCCGraduated.pm
+++ b/lib/DaxMailer/Script/DeletePCCGraduated.pm
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+package DaxMailer::Script::DeletePCCGraduated;
+
+use Moo;
+
+with 'DaxMailer::Base::Script::Service';
+
+sub go {
+    my ( $self ) = @_;
+
+    my $campaigns = config()->{campaigns};
+    for my $campaign ( sort keys %{ $campaigns } ) {
+        next if !$campaigns->{ $campaign }->{live};
+        my @mail_map = (
+            'v',
+            sort { $a <=> $b }
+            grep { /^[0-9]+$/ }
+            grep { !$campaigns->{ $campaign }->{mails}->{ $_ }->{oneoff} }
+            keys %{ $campaigns->{ $campaign }->{mails} }
+        );
+        my $mail = $mail_map[ $#mail_map - 1 ];
+        my @subscribers = rset('Subscriber')
+            ->campaign( $campaign )
+            ->subscribed
+            ->mail_sent( $campaign, $mail  )
+            ->all;
+            
+            
+        for my $subscriber ( @subscribers ) {
+            $subscriber->delete();
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
Script to delete users who "graduated" from the Privacy Crash Course (aka received all the campaign emails).