### PR TITLE
Delete users who subscribed more than 28 weeks ago

### DIFF
--- a/lib/DaxMailer/Script/DeletePCCGraduated.pm
+++ b/lib/DaxMailer/Script/DeletePCCGraduated.pm
@@ -3,6 +3,7 @@ use warnings;
 package DaxMailer::Script::DeletePCCGraduated;
 
 use Moo;
+use Data::Dumper;
 
 with 'DaxMailer::Base::Script::Service';
 
@@ -10,6 +11,8 @@ sub go {
     my ( $self ) = @_;
 
     my $campaigns = config()->{campaigns};
+    
+    # Delete Privacy Crash Course graduates
     for my $campaign ( sort keys %{ $campaigns } ) {
         my @mail_map = (
             'v',
@@ -18,17 +21,33 @@ sub go {
             grep { !$campaigns->{ $campaign }->{mails}->{ $_ }->{oneoff} }
             keys %{ $campaigns->{ $campaign }->{mails} }
         );
+
         my $mail = $mail_map[ $#mail_map - 1 ];
+
+        # Should be 26 or higher
+        warn Dumper( $mail );
+
         my @subscribers = rset('Subscriber')
             ->campaign( $campaign )
             ->subscribed
             ->mail_sent( $campaign, $mail  )
-            ->all;
-            
-            
+            ->all;    
+
         for my $subscriber ( @subscribers ) {
+            warn "Deleting graduated user $subscriber";
             $subscriber->delete();
         }
+    }
+
+
+    # Delete subscribers who signed up more than 28 weeks ago
+    my @old_subscribers = rset('Subscriber')
+        ->by_days_ago(203)
+        ->all;
+
+    for my $old_subscriber ( @old_subscribers) {
+        warn "Deleting old subscriber $old_subscriber";
+        $old_subscriber->delete();
     }
 }
 


### PR DESCRIPTION
Adding some code to the cronjob in #138 to also delete users who subscribed more than 28 weeks ago.
We rounded it up to 203 days which is 29 weeks (course length + 1 week to be sure).
Also added a bit of warn lines.